### PR TITLE
Fix entity styling fix, error catch while stopping recording

### DIFF
--- a/components/docs/README.md
+++ b/components/docs/README.md
@@ -10,7 +10,9 @@
 
 * ["components/BigTranscript.d"](modules/_components_bigtranscript_d_.md)
 * ["components/BigTranscriptContainer.d"](modules/_components_bigtranscriptcontainer_d_.md)
+* ["components/Callout.d"](modules/_components_callout_d_.md)
 * ["components/ErrorPanel.d"](modules/_components_errorpanel_d_.md)
+* ["components/HintCallout.d"](modules/_components_hintcallout_d_.md)
 * ["components/PushToTalkButton.d"](modules/_components_pushtotalkbutton_d_.md)
 * ["components/PushToTalkContainer.d"](modules/_components_pushtotalkcontainer_d_.md)
 * ["hooks/useKeyboardEvent.d"](modules/_hooks_usekeyboardevent_d_.md)

--- a/components/docs/README.md
+++ b/components/docs/README.md
@@ -10,9 +10,7 @@
 
 * ["components/BigTranscript.d"](modules/_components_bigtranscript_d_.md)
 * ["components/BigTranscriptContainer.d"](modules/_components_bigtranscriptcontainer_d_.md)
-* ["components/Callout.d"](modules/_components_callout_d_.md)
 * ["components/ErrorPanel.d"](modules/_components_errorpanel_d_.md)
-* ["components/HintCallout.d"](modules/_components_hintcallout_d_.md)
 * ["components/PushToTalkButton.d"](modules/_components_pushtotalkbutton_d_.md)
 * ["components/PushToTalkContainer.d"](modules/_components_pushtotalkcontainer_d_.md)
 * ["hooks/useKeyboardEvent.d"](modules/_hooks_usekeyboardevent_d_.md)

--- a/components/src/components/BigTranscript.tsx
+++ b/components/src/components/BigTranscript.tsx
@@ -83,7 +83,7 @@ const TransscriptItem: React.FC<{ word: ITaggedWord }> = props => {
   })
 
   return (
-    <TransscriptItemDiv className={`${props.word.entityType ?? 'Entity'} ${props.word.isFinal ? 'Final' : ''} ${props.word.entityType ?? ''}`}>
+    <TransscriptItemDiv className={`${props.word.entityType !== null ? 'Entity' : ''} ${props.word.isFinal ? 'Final' : ''} ${props.word.entityType ?? ''}`}>
       <TransscriptItemBgDiv style={springProps} />
       <TransscriptItemContent
         style={{

--- a/components/src/components/PushToTalkButton.tsx
+++ b/components/src/components/PushToTalkButton.tsx
@@ -128,8 +128,9 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
         initialise().catch(err => console.error('Error initiasing Speechly', err))
         break
       case SpeechState.Recording:
-      default:
         toggleRecording().catch(err => console.error('Error while stopping recording', err))
+        break
+      default:
         break
     }
 


### PR DESCRIPTION
### What

- BigTranscript: Fix entity styling with css
- PushToTalkButton: Record stop action done only when in recording state
